### PR TITLE
Test fix for Node 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "homepage": "https://github.com/ai-labs-team/ts-utils#readme",
   "dependencies": {
+    "@types/node": "^12.12.17",
     "ramda": "^0.26.1",
     "ts-toolbelt": "^4.8.19"
   },

--- a/package.json
+++ b/package.json
@@ -21,13 +21,13 @@
   },
   "homepage": "https://github.com/ai-labs-team/ts-utils#readme",
   "dependencies": {
-    "@types/node": "^12.12.17",
     "ramda": "^0.26.1",
     "ts-toolbelt": "^4.8.19"
   },
   "devDependencies": {
     "@types/chai": "^4.2.0",
     "@types/mocha": "^5.2.7",
+    "@types/node": "^12.12.17",
     "@types/ramda": "^0.26.33",
     "chai": "^4.2.0",
     "mocha": "^6.2.0",

--- a/src/decoder.spec.ts
+++ b/src/decoder.spec.ts
@@ -9,6 +9,7 @@ import {
 import Result from './result';
 import Maybe from './maybe';
 import { is, over, lensPath, concat, pipe } from 'ramda';
+import { URL } from 'url';
 
 const toDate = (val: string): Result<Error, Date> => (
   (isNaN(Date.parse(val)) || !is(String, val))

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,6 +12,11 @@
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-5.2.7.tgz#315d570ccb56c53452ff8638738df60726d5b6ea"
   integrity sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ==
 
+"@types/node@^12.12.17":
+  version "12.12.17"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.17.tgz#191b71e7f4c325ee0fb23bc4a996477d92b8c39b"
+  integrity sha512-Is+l3mcHvs47sKy+afn2O1rV4ldZFU7W8101cNlOd+MRbjM4Onida8jSZnJdTe/0Pcf25g9BNIUsuugmE6puHA==
+
 "@types/ramda@^0.26.33":
   version "0.26.33"
   resolved "https://registry.yarnpkg.com/@types/ramda/-/ramda-0.26.33.tgz#5fd1f22381ccf913a3627beb16f468fb57f82d94"


### PR DESCRIPTION
Two tests were failing on Node 8 because `URL` needs to be imported (until Node 10, where they work fine).